### PR TITLE
feat: detect URLs inside meta tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ The normalized value as URI.
 
 See [examples](/examples) for more!
 
+## Detection
+
+URLs are detected from:
+
+- **URL attributes**, such as `href`, `src`, `action`, `poster` or `ping`. The full map of attribute → tags is exposed as `htmlUrls.TAGS`.
+- **Metadata tags**, meaning `<meta>` tags whose `name`, `property` or `itemprop` is a known URL holder (`og:image`, `twitter:player`, `thumbnailUrl`, …). The full list is exposed as `htmlUrls.METAS`.
+- **Redirects** declared as `<meta http-equiv="refresh" content="0; url=/next">`.
+
+Metadata keys are an explicit list because most `<meta>` content is not addressable: resolving `content="width=device-width"` against the page URL would fabricate a URL that does not exist.
+
 ## API
 
 ### htmlUrls([options])

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { uniqBy, concat, isEmpty, reduce, get, findIndex } = require('lodash')
+const { uniqBy, concat, flatMap, isEmpty, map, reduce, get, findIndex } = require('lodash')
 const { normalizeUrl } = require('@metascraper/helpers')
 const isHttpUrl = require('is-url-http')
 const cheerio = require('cheerio')
@@ -25,6 +25,55 @@ const TAGS = {
   src: ['audio', 'embed', 'iframe', 'img', 'input', 'script', 'source', 'track', 'video']
 }
 
+/**
+ * Metadata keys whose `content` holds a URL. It is an explicit list because
+ * most `<meta>` content is not addressable (`width=device-width`, `ie=edge`)
+ * and resolving those against the base url would fabricate URLs.
+ */
+const METAS = [
+  'canonical',
+  'contentUrl',
+  'embedUrl',
+  'image',
+  'image_src',
+  'logo',
+  'msapplication-TileImage',
+  'msapplication-config',
+  'msapplication-starturl',
+  'og:audio',
+  'og:audio:secure_url',
+  'og:audio:url',
+  'og:image',
+  'og:image:secure_url',
+  'og:image:url',
+  'og:logo',
+  'og:see_also',
+  'og:url',
+  'og:video',
+  'og:video:secure_url',
+  'og:video:url',
+  'sameAs',
+  'shareurl',
+  'thumbnail',
+  'thumbnailUrl',
+  'twitter:image',
+  'twitter:image:src',
+  'twitter:player',
+  'twitter:player:stream',
+  'twitter:url',
+  'url'
+]
+
+const META_ATTRIBUTES = ['property', 'name', 'itemprop']
+
+const METAS_SELECTOR = flatMap(METAS, key =>
+  map(META_ATTRIBUTES, attribute => `meta[${attribute}="${key}" i]`)
+).join(',')
+
+const REFRESH_SELECTOR = 'meta[http-equiv="refresh" i]'
+
+const REFRESH_URL_REGEX = /^\s*[^;]*;\s*url\s*=\s*(?:'([^']*)'|"([^"]*)"|(.*?))\s*$/i
+
 const reduceSelector = (collection, fn, acc = []) => {
   collection.each(function () {
     acc = fn(acc, this)
@@ -34,27 +83,35 @@ const reduceSelector = (collection, fn, acc = []) => {
 
 const includes = (collection, fn) => findIndex(collection, fn) !== -1
 
-const getLink = ({ url, el, attribute }) => {
-  const attr = get(el, `attribs.${attribute}`, '')
-  if (isEmpty(attr)) return undefined
-  const absoluteUrl = url ? normalizeUrl(url, attr) : normalizeUrl(attr)
+const getAttribute = attribute => el => get(el, `attribs.${attribute}`, '')
+
+const getContent = getAttribute('content')
+
+const getRefreshContent = el => {
+  const match = REFRESH_URL_REGEX.exec(getContent(el))
+  return match === null ? '' : match[1] || match[2] || match[3] || ''
+}
+
+const getLink = ({ url, value }) => {
+  if (isEmpty(value)) return undefined
+  const absoluteUrl = url ? normalizeUrl(url, value) : normalizeUrl(value)
   return {
-    value: attr,
+    value,
     url: isHttpUrl(absoluteUrl) ? absoluteUrl : undefined,
     uri: isUri(absoluteUrl) ? absoluteUrl : undefined
   }
 }
 
-const createGetLinksByAttribute = ({ removeDuplicates }) => {
+const createGetLinks = ({ removeDuplicates }) => {
   const has = removeDuplicates
     ? (acc, uid) => includes(acc, item => get(item, UID) === uid)
     : () => false
 
-  return ({ selector, attribute, url, whitelist }) =>
+  return ({ selector, getValue, url, whitelist }) =>
     reduceSelector(
       selector,
       (acc, el) => {
-        const link = getLink({ url, el, attribute })
+        const link = getLink({ url, value: getValue(el) })
         const uid = get(link, UID)
         if (isEmpty(link)) return acc
         const isAlreadyAdded = has(acc, uid)
@@ -81,21 +138,24 @@ module.exports = ({
   const $ = cheerio.load(html, cheerioOpts)
 
   const add = createAdd({ removeDuplicates })
-  const getLinksByAttribute = createGetLinksByAttribute({ removeDuplicates })
+  const getLinks = createGetLinks({ removeDuplicates })
+
+  const sources = concat(
+    map(TAGS, (htmlTags, attribute) => ({
+      selector: htmlTags.join(','),
+      getValue: getAttribute(attribute)
+    })),
+    { selector: METAS_SELECTOR, getValue: getContent },
+    { selector: REFRESH_SELECTOR, getValue: getRefreshContent }
+  )
 
   return reduce(
-    TAGS,
-    (acc, htmlTags, attribute) => {
-      const links = getLinksByAttribute({
-        selector: $(htmlTags.join(',')),
-        attribute,
-        url,
-        whitelist
-      })
-      return add(acc, links)
-    },
+    sources,
+    (acc, { selector, getValue }) =>
+      add(acc, getLinks({ selector: $(selector), getValue, url, whitelist })),
     []
   )
 }
 
 module.exports.TAGS = TAGS
+module.exports.METAS = METAS

--- a/test/metas.js
+++ b/test/metas.js
@@ -1,0 +1,114 @@
+'use strict'
+
+const { forEach } = require('lodash')
+const test = require('ava').default
+
+const getLinks = require('..')
+
+const { METAS } = getLinks
+
+const generateHtml = metas => `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>hello world</title>
+  ${metas.join('\n')}
+</head>
+<body>
+</body>
+</html>
+`
+
+forEach(METAS, key => {
+  forEach(['property', 'name', 'itemprop'], attribute => {
+    test(`${key} (${attribute})`, t => {
+      const html = generateHtml([`<meta ${attribute}="${key}" content="/image.png">`])
+      t.deepEqual(getLinks({ html, url: 'https://example.com' }), [
+        {
+          value: '/image.png',
+          url: 'https://example.com/image.png',
+          uri: 'https://example.com/image.png'
+        }
+      ])
+    })
+  })
+})
+
+test('metadata keys are matched case insensitively', t => {
+  const html = generateHtml(['<meta property="OG:IMAGE" content="https://example.com/a.png">'])
+  t.deepEqual(getLinks({ html }), [
+    {
+      value: 'https://example.com/a.png',
+      url: 'https://example.com/a.png',
+      uri: 'https://example.com/a.png'
+    }
+  ])
+})
+
+// The regression this list exists for: resolving any `<meta content>` against
+// the base url turns `width=device-width` into `https://example.com/width=device-width`.
+test('ignores meta tags whose content is not a URL', t => {
+  const html = generateHtml([
+    '<meta name="description" content="hello world">',
+    '<meta property="og:title" content="hello world">',
+    '<meta property="og:image:width" content="1200">',
+    '<meta name="robots" content="index, follow">'
+  ])
+  t.deepEqual(getLinks({ html, url: 'https://example.com' }), [])
+})
+
+test('deduplicates a meta url already present as a tag url', t => {
+  const html = generateHtml([
+    '<link href="https://example.com/a">',
+    '<meta property="og:url" content="https://example.com/a">'
+  ])
+  t.deepEqual(getLinks({ html }), [
+    { value: 'https://example.com/a', url: 'https://example.com/a', uri: 'https://example.com/a' }
+  ])
+})
+
+test('keeps a meta url duplicated when removeDuplicates is disabled', t => {
+  const html = generateHtml([
+    '<link href="https://example.com/a">',
+    '<meta property="og:url" content="https://example.com/a">'
+  ])
+  t.is(getLinks({ html, removeDuplicates: false }).length, 2)
+})
+
+test('excludes meta urls matching the whitelist', t => {
+  const html = generateHtml(['<meta property="og:image" content="https://example.com/a.png">'])
+  t.deepEqual(getLinks({ html, whitelist: ['https://example.com*'] }), [])
+})
+
+test('detects the url of a meta refresh redirect', t => {
+  const html = generateHtml(['<meta http-equiv="refresh" content="0; url=/next">'])
+  t.deepEqual(getLinks({ html, url: 'https://example.com' }), [
+    { value: '/next', url: 'https://example.com/next', uri: 'https://example.com/next' }
+  ])
+})
+
+test('detects a meta refresh url written with quotes and odd casing', t => {
+  const html = generateHtml([
+    '<meta HTTP-EQUIV="Refresh" content="5;URL=\'https://example.com/next\'">'
+  ])
+  t.deepEqual(getLinks({ html }), [
+    {
+      value: 'https://example.com/next',
+      url: 'https://example.com/next',
+      uri: 'https://example.com/next'
+    }
+  ])
+})
+
+test('ignores a meta refresh without a url', t => {
+  const html = generateHtml(['<meta http-equiv="refresh" content="30">'])
+  t.deepEqual(getLinks({ html, url: 'https://example.com' }), [])
+})
+
+test('ignores a meta refresh with an empty url', t => {
+  const html = generateHtml(['<meta http-equiv="refresh" content="0; url=">'])
+  t.deepEqual(getLinks({ html, url: 'https://example.com' }), [])
+})


### PR DESCRIPTION
Extract URLs from <meta> tags whose name/property/itemprop is a known URL holder (og:image, twitter:player, thumbnailUrl, ...), exposed as METAS, plus the target of <meta http-equiv="refresh">.

The keys are an explicit list rather than every <meta content>: resolving content="width=device-width" against the page URL would fabricate a URL.

Closes #46


Claude-Session: https://claude.ai/code/session_017Rg6dkckm8mFxjptQZnUQ6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broader HTML surface for extracted URLs and a refactor of the main reduction loop; behavior is constrained by an explicit meta key list and covered by new regression tests for non-URL meta content and deduplication.
> 
> **Overview**
> Extends **html-urls** so link discovery covers SEO/social metadata and refresh redirects, not only classic URL-bearing attributes.
> 
> A fixed **`METAS`** allowlist drives `<meta>` matching on `property`, `name`, and `itemprop` (case-insensitive), so only known URL-holding keys like `og:image` and `twitter:player` contribute—arbitrary meta `content` is not resolved against the page URL. **`meta http-equiv="refresh"`** targets are parsed from `content` (quoted/unquoted `url=`, odd casing). The internal pipeline is unified: attribute tags, meta content, and refresh each supply a selector plus **`getValue`**, replacing the old per-attribute-only path. **`htmlUrls.METAS`** is exported alongside **`TAGS`**, and the README documents the three detection sources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e266554377535b766c315a195210fadb5f241806. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->